### PR TITLE
support repository as input

### DIFF
--- a/create-pull-request/action.yml
+++ b/create-pull-request/action.yml
@@ -17,6 +17,9 @@ inputs:
   token:
     description: A GitHub access token
     required: true
+  repository:
+    description: The GitHub owner and repository name. E.g. `babel/website`. By default it is the repo where the workflow is called
+    required: false
 
 runs:
   using: node16

--- a/create-pull-request/main.js
+++ b/create-pull-request/main.js
@@ -12,7 +12,7 @@ const title = core.getInput("title", { required: true });
 const description = core.getInput("description", { required: true });
 const labels = core.getInput("labels");
 
-const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+const [owner, repo] = (core.getInput("repository") || process.env.GITHUB_REPOSITORY).split("/");
 
 const octokit = new github.GitHub(token);
 


### PR DESCRIPTION
This feature will be used by the babel types docs update workflow:

https://github.com/babel/babel/blob/576a14adc4a54dce40457098b38b8e4e070a9c6b/.github/workflows/release.yml#L313-L324

After this PR gets merged, we should release `v3`. We can also upgrade the depending nodejs images.